### PR TITLE
Maximise table component and Make UI Responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
   },
   toolbar: {
+    height: '75px',
     paddingRight: 24, // keep right padding when drawer closed
   },
   toolbarIcon: {
@@ -93,10 +94,13 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
     height: '100vh',
     overflow: 'auto',
+    overflowY: 'hidden',
   },
   container: {
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
+    overflowY: 'hidden',
+    height: '100vh',
   },
   paper: {
     padding: theme.spacing(2),
@@ -118,8 +122,9 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 export default function App() {
+  const widthMobile = window.innerWidth < 601 ? false : true
   const classes = useStyles()
-  const [open, setOpen] = React.useState(true)
+  const [open, setOpen] = React.useState(widthMobile)
   const handleDrawerOpen = () => {
     setOpen(true)
   }

--- a/src/components/PatentList.tsx
+++ b/src/components/PatentList.tsx
@@ -271,40 +271,7 @@ function PatentList(props: any) {
       <Card className={classes.detailsCard} variant="outlined">
         <Title>Patent Details</Title>
         <CardContent className={classes.detailsCardContent}>
-            {data.Patent.filter((patent: Patent) => patent.lens_id === currentDisplayInfo).map((filteredPatent: Patent) => (
-              <div key={filteredPatent?.lens_id}>
-                {filteredPatent.titles ? distinctGeneSymbols(filteredPatent.titles).map((geneSymbol) => {
-                    return <div key={geneSymbol.sid}>{geneSymbol.sid}</div>
-                  }) : "n/a"}
-                  <Divider variant="fullWidth" />
-                  Lens ID: {filteredPatent.lens_id}
-                  <Divider variant="fullWidth" />
-                  Lens URL: {filteredPatent.lens_url}
-                  <Divider variant="fullWidth" />
-                  Filing Key: {filteredPatent.filing_key}
-                  <Divider variant="fullWidth" />
-                  Filing Date: {filteredPatent.filing_date}
-                  <Divider variant="fullWidth" />
-                  Jurisdiction: {filteredPatent.jurisdiction}
-                  <Divider variant="fullWidth" />
-                  Publication date: {filteredPatent.pub_date}
-                  <Divider variant="fullWidth" />
-                  Publication Key: {filteredPatent.pub_key}
-                  <Divider variant="fullWidth" />
-                  Type: {filteredPatent.type}
-                  <Divider variant="fullWidth" />
-                  Titles:
-                  <br/>
-                  {filteredPatent.titles?.map((patentTitles: Maybe<_PatentTitles>) => {
-                    return (
-                      <div key={patentTitles?._id}>
-                        {patentTitles?.title?.lang}: {patentTitles?.title?.text}
-                        <br/>
-                      </div>
-                    )
-                  })}
-              </div>
-            ))}
+          {detailedInformation(patentId)}
         </CardContent>
       </Card>
     )
@@ -321,40 +288,7 @@ function PatentList(props: any) {
         <DialogTitle id="responsive-dialog-title"><Title>Patent Details</Title></DialogTitle>
         <DialogContent>
           <DialogContentText>
-          {data.Patent.filter((patent: Patent) => patent.lens_id === currentDisplayInfo).map((filteredPatent: Patent) => (
-              <div key={filteredPatent?.lens_id}>
-                {filteredPatent.titles ? distinctGeneSymbols(filteredPatent.titles).map((geneSymbol) => {
-                    return <div key={geneSymbol.sid}>{geneSymbol.sid}</div>
-                  }) : "n/a"}
-                  <Divider variant="fullWidth" />
-                  Lens ID: {filteredPatent.lens_id}
-                  <Divider variant="fullWidth" />
-                  Lens URL: {filteredPatent.lens_url}
-                  <Divider variant="fullWidth" />
-                  Filing Key: {filteredPatent.filing_key}
-                  <Divider variant="fullWidth" />
-                  Filing Date: {filteredPatent.filing_date}
-                  <Divider variant="fullWidth" />
-                  Jurisdiction: {filteredPatent.jurisdiction}
-                  <Divider variant="fullWidth" />
-                  Publication date: {filteredPatent.pub_date}
-                  <Divider variant="fullWidth" />
-                  Publication Key: {filteredPatent.pub_key}
-                  <Divider variant="fullWidth" />
-                  Type: {filteredPatent.type}
-                  <Divider variant="fullWidth" />
-                  Titles:
-                  <br/>
-                  {filteredPatent.titles?.map((patentTitles: Maybe<_PatentTitles>) => {
-                    return (
-                      <div key={patentTitles?._id}>
-                        {patentTitles?.title?.lang}: {patentTitles?.title?.text}
-                        <br/>
-                      </div>
-                    )
-                  })}
-              </div>
-            ))}
+            {detailedInformation(patentId)}
           </DialogContentText>
         </DialogContent>
         <DialogActions>
@@ -363,6 +297,45 @@ function PatentList(props: any) {
           </Button>
         </DialogActions>
       </Dialog>
+    )
+  }
+
+  const detailedInformation = (patentId: any) => {
+    return (
+      data.Patent.filter((patent: Patent) => patent.lens_id === currentDisplayInfo).map((filteredPatent: Patent) => (
+        <div key={filteredPatent?.lens_id}>
+          {filteredPatent.titles ? distinctGeneSymbols(filteredPatent.titles).map((geneSymbol) => {
+              return <div key={geneSymbol.sid}>{geneSymbol.sid}</div>
+            }) : "n/a"}
+            <Divider variant="fullWidth" />
+            Lens ID: {filteredPatent.lens_id}
+            <Divider variant="fullWidth" />
+            Lens URL: {filteredPatent.lens_url}
+            <Divider variant="fullWidth" />
+            Filing Key: {filteredPatent.filing_key}
+            <Divider variant="fullWidth" />
+            Filing Date: {filteredPatent.filing_date}
+            <Divider variant="fullWidth" />
+            Jurisdiction: {filteredPatent.jurisdiction}
+            <Divider variant="fullWidth" />
+            Publication date: {filteredPatent.pub_date}
+            <Divider variant="fullWidth" />
+            Publication Key: {filteredPatent.pub_key}
+            <Divider variant="fullWidth" />
+            Type: {filteredPatent.type}
+            <Divider variant="fullWidth" />
+            Titles:
+            <br/>
+            {filteredPatent.titles?.map((patentTitles: Maybe<_PatentTitles>) => {
+              return (
+                <div key={patentTitles?._id}>
+                  {patentTitles?.title?.lang}: {patentTitles?.title?.text}
+                  <br/>
+                </div>
+              )
+            })}
+        </div>
+      ))
     )
   }
 


### PR DESCRIPTION
Maximise table component and make UI responsive github issues. The more information box now becomes a fullscreen dialog box when the screen becomes to small to display side by side with the table.

The table scrolls horizontally, and vertically. The header always stays in view and scrolls horizontally with the table.

The sidebar draw is closed on mobile loadup.

Ref: #6 #11

![image](https://user-images.githubusercontent.com/75426130/105985204-13962c80-6093-11eb-8b25-e2a97e5f472e.png)
![image](https://user-images.githubusercontent.com/75426130/105985253-214bb200-6093-11eb-8ff9-465d3e5a458f.png)
![image](https://user-images.githubusercontent.com/75426130/105985293-30326480-6093-11eb-89f6-c55e9b195e19.png)
![image](https://user-images.githubusercontent.com/75426130/105985359-43453480-6093-11eb-8f64-ae5a0abe510f.png)
